### PR TITLE
Fix error with spaces in path/filename

### DIFF
--- a/TikaApp.php
+++ b/TikaApp.php
@@ -8,7 +8,7 @@ class TikaApp
 {
     private function execute($option, \SplFileInfo $file)
     {
-        $command = 'java -jar tika-app-1.1.jar '.$option.' '.$file->getRealPath();
+        $command = 'java -jar tika-app-1.1.jar '.$option.' '."'".$file->getRealPath()."'";
         $cwd = __DIR__.'/vendor/';
         $process = new Process($command);
         $process->setWorkingDirectory($cwd);


### PR DESCRIPTION
When loading files from a remote server, sometimes the path or filename
has a space, this handles the otherwise annoying
“java.net.MalformedURLException: no protocol” error.
